### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a **Jekyll static site** for [markussens.se](http://markussens.se/) (Markussens Studiefond — a Swedish scholarship foundation). It is hosted on GitHub Pages from the `gh-pages` branch.
+
+### Tech stack
+
+- **Ruby 3.4.2** (specified in `Gemfile`; `.ruby-version` says 2.7.2 but `Gemfile` takes precedence)
+- **Jekyll 3.10** via the `github-pages` gem
+- **Sass** (deprecated Ruby Sass) with Bourbon, Singularity, Breakpoint-sass libraries vendored in `_sass/`
+- **Bundler** for Ruby dependency management
+
+### Running the dev server
+
+```sh
+bundle exec jekyll serve --watch --host 0.0.0.0 --port 4000
+```
+
+The site will be at `http://localhost:4000/`. All three pages (Start, Presentation, Historik) should return HTTP 200.
+
+### Building
+
+```sh
+bundle exec jekyll build
+```
+
+Output goes to `_site/`. Sass deprecation warnings about `call()` are expected and harmless.
+
+### Validation / linting
+
+```sh
+bundle exec htmlproofer ./_site --disable-external
+```
+
+Known pre-existing failures (12 total): non-HTTPS links, protocol-relative jQuery URL, and obfuscated email addresses. These are in the existing codebase and not regressions.
+
+### Gotchas
+
+- Ruby is installed at `/usr/local/ruby-3.4.2/bin` — ensure this is on `PATH`.
+- The `bower.json` / `.bowerrc` files exist but Sass dependencies are already vendored in `_sass/`; Bower is **not** needed.
+- The `github-pages` gem pins Jekyll to 3.10 and many plugins to specific versions. Do not upgrade individual gems without checking compatibility.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents working on this Jekyll static site.

### What's included

- Tech stack overview (Ruby 3.4.2, Jekyll 3.10 via `github-pages` gem, Sass, Bundler)
- Dev server startup command (`bundle exec jekyll serve --watch`)
- Build command (`bundle exec jekyll build`)
- Validation/linting command (`bundle exec htmlproofer`)
- Known gotchas (Ruby path, vendored Bower deps, pinned gem versions)

### Environment verification

All three pages verified working:

[jekyll_site_demo.mp4](https://cursor.com/agents/bc-f3c352ec-dc84-480c-a8bd-374b7820c8f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fjekyll_site_demo.mp4)

[Homepage](https://cursor.com/agents/bc-f3c352ec-dc84-480c-a8bd-374b7820c8f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhomepage.webp)
[Presentation page](https://cursor.com/agents/bc-f3c352ec-dc84-480c-a8bd-374b7820c8f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpresentation_page.webp)
[Historik page](https://cursor.com/agents/bc-f3c352ec-dc84-480c-a8bd-374b7820c8f8/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhistorik_page.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-f3c352ec-dc84-480c-a8bd-374b7820c8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-f3c352ec-dc84-480c-a8bd-374b7820c8f8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

